### PR TITLE
Install requires pycryptodome, not pycrypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ blog platform on cryptedblog.com which is based on sjcl.
     ],
     package_dir={'sjcl': 'sjcl'},
     include_package_data=True,
-    install_requires=['pycrypto'], # TODO add version >=
+    install_requires=['pycryptodome'], # TODO add version >=
     license="new-style BSD",
     zip_safe=False,
     keywords='SJCL, AES, encryption, pycrypto, Javascript',


### PR DESCRIPTION
PyCrypto version on PyPi is 2.6, but sjcl requires 2.7.
PyCrypto is not maintained. PyCryptodome is a drop in replacement.

A fresh install of sjcl with PyCrypto in Python 3.6.1 on macOS results
in error on:
  File "/Users/jthetzel/.local/src/py_test/venv/lib/python3.6/
  site-packages/sjcl/sjcl.py", line 76, in check_mode_ccm
    "You need a version >= 2.7a1 (or a special branch)."
  Exception: Pycrypto does not seem to support MODE_CCM.
  You need a version >= 2.7a1 (or a special branch).

A fresh install of sjcl with PyCryptodome has no error.
PyCryptodome repo at https://github.com/Legrandin/pycryptodome